### PR TITLE
Pool integration

### DIFF
--- a/test/fixtures/mock-rpc-server.js
+++ b/test/fixtures/mock-rpc-server.js
@@ -1,0 +1,33 @@
+'use strict'
+
+const uuid = require('uuid').v4()
+
+const Grenache = require('./../../')
+const Link = Grenache.Link
+const PeerRPCServer = Grenache.PeerRPCServer
+
+const _ = require('lodash')
+
+let RESPONSE = process.argv[2]
+if (!RESPONSE) {
+  RESPONSE = uuid
+}
+
+const link = new Link({
+  grape: 'ws://127.0.0.1:30001'
+})
+link.start()
+
+const peer = new PeerRPCServer(link, {})
+peer.init()
+
+const service = peer.transport('server')
+service.listen(_.random(1000) + 1024)
+
+setInterval(function () {
+  link.announce('rpc_test', service.port, {})
+}, 1000)
+
+service.on('request', (rid, key, payload, handler) => {
+  handler.reply(null, RESPONSE)
+})

--- a/test/helper.js
+++ b/test/helper.js
@@ -23,3 +23,14 @@ function bootTwoGrapes () {
 
   return [ grape1, grape2 ]
 }
+
+exports.killGrapes = killGrapes
+function killGrapes (grapes, done) {
+  grapes[0].stop((err) => {
+    if (err) throw err
+    grapes[1].stop((err) => {
+      if (err) throw err
+      done()
+    })
+  })
+}

--- a/test/helper.js
+++ b/test/helper.js
@@ -1,17 +1,16 @@
 'use strict'
+
 const { Grape } = require('grenache-grape')
+const waterfall = require('async/waterfall')
 
 exports.bootTwoGrapes = bootTwoGrapes
-function bootTwoGrapes () {
+function bootTwoGrapes (cb) {
   const grape1 = new Grape({
     dht_port: 20002,
     dht_bootstrap: [ '127.0.0.1:20001', '127.0.0.1:20003' ],
     api_port: 40001,
     api_port_http: 40002
   })
-
-  grape1.start(() => {})
-
   const grape2 = new Grape({
     dht_port: 20001,
     dht_bootstrap: [ '127.0.0.1:20002', '127.0.0.1:20003' ],
@@ -19,9 +18,18 @@ function bootTwoGrapes () {
     api_port_http: 30002
   })
 
-  grape2.start(() => {})
-
-  return [ grape1, grape2 ]
+  waterfall([
+    (cb) => {
+      grape1.start()
+      grape1.once('ready', cb)
+    },
+    (cb) => {
+      grape2.start()
+      grape2.once('node', cb)
+    }
+  ], () => {
+    cb(null, [ grape1, grape2 ])
+  })
 }
 
 exports.killGrapes = killGrapes

--- a/test/integration-client-server-multiple-server-loadbalance.js
+++ b/test/integration-client-server-multiple-server-loadbalance.js
@@ -7,12 +7,14 @@ const spawn = require('child_process').spawn
 const path = require('path')
 
 const parallel = require('async/parallel')
-const Peer = require('./../').PeerRPCClient
+const _ = require('lodash')
+
+const PeerRPCClient = require('./../').PeerRPCClient
 const Link = require('./../').Link
 const { bootTwoGrapes, killGrapes } = require('./helper')
 
-let rpc, grapes
-describe('RPC integration', () => {
+let rpc1, rpc2, grapes
+describe('RPC socket pools / loadbalancing', () => {
   before(function (done) {
     this.timeout(8000)
 
@@ -23,28 +25,33 @@ describe('RPC integration', () => {
 
     grapes[1].on('ready', () => {
       const f = path.join(__dirname, 'fixtures', 'mock-rpc-server.js')
-      rpc = spawn('node', [ f, 'world' ])
+      rpc1 = spawn('node', [ f ])
+      rpc2 = spawn('node', [ f ])
     })
   })
 
   after(function (done) {
     this.timeout(5000)
-    rpc.on('close', () => {
-      killGrapes(grapes, done)
+    rpc1.on('close', () => {
+      rpc2.on('close', () => {
+        killGrapes(grapes, done)
+      })
+      rpc2.kill()
     })
-    rpc.kill()
+
+    rpc1.kill()
   })
 
-  it('messages with the rpc worker', (done) => {
+  it('maps over multiple servers', (done) => {
     const link = new Link({
       grape: 'ws://127.0.0.1:30001'
     })
     link.start()
 
-    const peer = new Peer(link, {})
+    const peer = new PeerRPCClient(link, {})
     peer.init()
 
-    const reqs = 5
+    const reqs = 10
     const tasks = []
 
     function createTask () {
@@ -62,8 +69,18 @@ describe('RPC integration', () => {
     link.on('connect', () => {
       parallel(tasks, (err, data) => {
         if (err) throw err
-        assert.equal(data[0][0], 'world')
-        assert.equal(data.length, 5)
+
+        assert.equal(data.length, 10)
+
+        const uuidList = data.reduce((acc, el) => {
+          acc.push(el[0], el[1])
+          return acc
+        }, [])
+
+        const uuids = _.uniq(uuidList)
+
+        assert.equal(uuids.length, 2)
+
         done()
       })
     })

--- a/test/integration-client-server-multiple-server-loadbalance.js
+++ b/test/integration-client-server-multiple-server-loadbalance.js
@@ -17,13 +17,14 @@ let rpc1, rpc2, grapes
 describe('RPC socket pools / loadbalancing', () => {
   before(function (done) {
     this.timeout(8000)
+    bootTwoGrapes((err, g) => {
+      if (err) throw err
 
-    grapes = bootTwoGrapes()
-    grapes[0].once('announce', (msg) => {
-      done()
-    })
+      grapes = g
+      grapes[0].once('announce', (msg) => {
+        done()
+      })
 
-    grapes[1].on('ready', () => {
       const f = path.join(__dirname, 'fixtures', 'mock-rpc-server.js')
       rpc1 = spawn('node', [ f ])
       rpc2 = spawn('node', [ f ])

--- a/test/integration-client-server-rpc.js
+++ b/test/integration-client-server-rpc.js
@@ -16,12 +16,14 @@ describe('RPC integration', () => {
   before(function (done) {
     this.timeout(8000)
 
-    grapes = bootTwoGrapes()
-    grapes[0].once('announce', (msg) => {
-      done()
-    })
+    bootTwoGrapes((err, g) => {
+      if (err) throw err
 
-    grapes[1].on('ready', () => {
+      grapes = g
+      grapes[0].once('announce', (msg) => {
+        done()
+      })
+
       const f = path.join(__dirname, 'fixtures', 'mock-rpc-server.js')
       rpc = spawn('node', [ f, 'world' ])
     })

--- a/test/integration-pubsub.js
+++ b/test/integration-pubsub.js
@@ -15,26 +15,17 @@ describe('Pub/Sub integration', () => {
   before(function (done) {
     this.timeout(10000)
 
-    grapes = bootTwoGrapes()
-    grapes[0].once('announce', (msg) => {
-      done()
-    })
+    bootTwoGrapes((err, g) => {
+      if (err) throw err
 
-    let bootedGrapes = 0
-    grapes[0].once('ready', () => {
-      bootedGrapes++
-      if (bootedGrapes === 2) spawnServer()
-    })
+      grapes = g
+      grapes[0].once('announce', (msg) => {
+        done()
+      })
 
-    grapes[1].once('ready', () => {
-      bootedGrapes++
-      if (bootedGrapes === 2) spawnServer()
-    })
-
-    function spawnServer () {
       const f = path.join(__dirname, '..', 'examples', 'pub.js')
       pub = spawn('node', [ f ])
-    }
+    })
   })
 
   after(function (done) {


### PR DESCRIPTION
This integration test boots 2 different RPC workers, each with an own UUID.

The handler of the server send its UUID as a reply message.

We map 10 tasks, and then take a look which UUIDs were part of the reply and if both UUIDS exist.

--- 

 - test: fix grape bootstrapping 

this fixes a weird timing related bootstrapping error for grape that just happened as soon as the third test was running. test order did not make a difference.